### PR TITLE
implement query and header tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,40 @@ type Foo struct {
 }
 
 type BarRequest struct {
-	...
+	// These fields are stored in JSON format in body.
+	Name string `json:"name"`
+
+	// These fields are GET parameters.
+	UserID int `query:"user_id"`
+
+	// These fields are headers.
+	FileHash string `header:"file_hash"`
+
+	// These fields are skipped.
+	SkippedField int `json:"-"`
 }
 
 type BarResponse struct {
-	...
+	// These fields are stored in JSON format in body.
+	FileSize int `json:"file_size"`
+
+	// These fields are headers.
+	FileHash string `header:"file_hash"`
+
+	// These fields are skipped.
+	SkippedField int `json:"-"`
 }
 
 func (s *Foo) Bar(ctx context.Context, req *BarRequest) (*BarResponse, error) {
 	...
 }
 ```
+
+A field must not have more than one of tags: `json`, `query`, `header`.
+Fields in query and header parts are encoded and decoded with
+`fmt.Sprintf` and `fmt.Sscanf`. Strings are not decoded with `fmt.Sscanf`,
+but passed as is. Types implementing `encoding.TextMarshaler` and
+`encoding.TextUnmarshaler` are encoded and decoded using it.
 
 Now let's write the function that generates the table of routes:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ func GetRoutes(s *Foo) []api2.Route {
 You can add multiple routes with the same path, but in this case their
 HTTP methods must be different so that they can be distinguished.
 
+If `Transport` is not set, `DefaultTransport` is used which is defined as
+`&api2.JsonTransport{}`.
+
 In the server you need a real instance of service Foo to pass to GetRoutes.
 Then just bind the routes to http.ServeMux and run the server:
 

--- a/api.go
+++ b/api.go
@@ -22,7 +22,8 @@ type Route struct {
 	// Request and Response are custom structures, unique to this route.
 	Handler interface{}
 
-	// The transport used in this route.
+	// The transport used in this route. If Transport is not set, DefaultTransport
+	// is used.
 	Transport Transport
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,97 @@
+package api2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidateRequestResponse(t *testing.T) {
+	cases := []struct {
+		obj       interface{}
+		request   bool
+		wantPanic bool
+	}{
+		{
+			obj: struct {
+				Foo string `json:"foo"`
+			}{},
+			request: true,
+		},
+		{
+			obj: struct {
+				Foo string `json:"foo"`
+			}{},
+			request: false,
+		},
+		{
+			obj: struct {
+				Foo string `query:"foo"`
+			}{},
+			request: true,
+		},
+		{
+			obj: struct {
+				Foo string `query:"foo"`
+			}{},
+			request:   false,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo string `header:"foo"`
+			}{},
+			request: true,
+		},
+		{
+			obj: struct {
+				Foo string `header:"foo"`
+			}{},
+			request: false,
+		},
+		{
+			obj: struct {
+				Foo string `json:"foo" query:"foo"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo string `header:"foo" query:"foo"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo string `json:"foo" header:"foo"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo string `json:"foo" header:"foo" query:"foo"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+	}
+
+	for i, tc := range cases {
+		var message interface{}
+		gotPanic := func() (gotPanic bool) {
+			defer func() {
+				if r := recover(); r != nil {
+					gotPanic = true
+					message = r
+				}
+			}()
+			validateRequestResponse(reflect.TypeOf(tc.obj), tc.request)
+			return
+		}()
+		if gotPanic != tc.wantPanic {
+			t.Errorf("case %d: gotPanic=%v, wantPanic=%v, message=%v", i, gotPanic, tc.wantPanic, message)
+		}
+	}
+}

--- a/client.go
+++ b/client.go
@@ -81,9 +81,14 @@ func (c *Client) Call(ctx context.Context, response, request interface{}) error 
 		panic(fmt.Sprintf("No registered method with signature %v %v.", key.request, key.response))
 	}
 
+	t := route.Transport
+	if t == nil {
+		t = DefaultTransport
+	}
+
 	url := c.baseURL + route.Path
 
-	req, err := route.Transport.EncodeRequest(ctx, route.Method, url, request)
+	req, err := t.EncodeRequest(ctx, route.Method, url, request)
 	if err != nil {
 		return fmt.Errorf("failed to encode request: %w", err)
 	}
@@ -100,8 +105,8 @@ func (c *Client) Call(ctx context.Context, response, request interface{}) error 
 
 	// Handle all 2xx responses as success.
 	if 200 <= res.StatusCode && res.StatusCode < 300 {
-		return route.Transport.DecodeResponse(req.Context(), res, response)
+		return t.DecodeResponse(req.Context(), res, response)
 	} else {
-		return route.Transport.DecodeError(req.Context(), res)
+		return t.DecodeError(req.Context(), res)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -15,16 +15,39 @@ Let's define a service Foo with method Bar.
 	}
 
 	type BarRequest struct {
-		...
+		// These fields are stored in JSON format in body.
+		Name string `json:"name"`
+
+		// These fields are GET parameters.
+		UserID int `query:"user_id"`
+
+		// These fields are headers.
+		FileHash string `header:"file_hash"`
+
+		// These fields are skipped.
+		SkippedField int `json:"-"`
 	}
 
 	type BarResponse struct {
-		...
+		// These fields are stored in JSON format in body.
+		FileSize int `json:"file_size"`
+
+		// These fields are headers.
+		FileHash string `header:"file_hash"`
+
+		// These fields are skipped.
+		SkippedField int `json:"-"`
 	}
 
 	func (s *Foo) Bar(ctx context.Context, req *BarRequest) (*BarResponse, error) {
 		...
 	}
+
+A field must not have more than one of tags: json, query, header.
+Fields in query and header parts are encoded and decoded with
+fmt.Sprintf and fmt.Sscanf. Strings are not decoded with fmt.Sscanf,
+but passed as is. Types implementing encoding.TextMarshaler and
+encoding.TextUnmarshaler are encoded and decoded using it.
 
 Now let's write the function that generates the table of routes:
 

--- a/doc.go
+++ b/doc.go
@@ -65,6 +65,9 @@ Now let's write the function that generates the table of routes:
 You can add multiple routes with the same path, but in this case their
 HTTP methods must be different so that they can be distinguished.
 
+If Transport is not set, DefaultTransport is used which is defined as
+&api2.JsonTransport{}.
+
 In the server you need a real instance of service Foo to pass to GetRoutes.
 Then just bind the routes to http.ServeMux and run the server:
 

--- a/json_transport.go
+++ b/json_transport.go
@@ -3,11 +3,16 @@ package api2
 import (
 	"bytes"
 	"context"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
 )
 
 // JsonTransport implements interface Transport for JSON encoding of requests and responses.
@@ -32,13 +37,19 @@ func (h *JsonTransport) DecodeRequest(ctx context.Context, r *http.Request, req 
 	if h.RequestDecoder != nil {
 		return h.RequestDecoder(ctx, r, req)
 	}
-	err := json.NewDecoder(r.Body).Decode(req)
 
 	// Calling FormValue before parsing JSON "eats" r.Body if Content-Type is
 	// application/x-www-form-urlencoded. This happens in curl for me.
 	ctx = context.WithValue(ctx, humanType{}, r.FormValue("human") != "")
 
-	return ctx, err
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		return ctx, err
+	}
+	if err := parseQueryAndHeader(req, r.URL.Query(), r.Header); err != nil {
+		return ctx, err
+	}
+
+	return ctx, nil
 }
 
 func (h *JsonTransport) EncodeResponse(ctx context.Context, w http.ResponseWriter, res interface{}) error {
@@ -46,11 +57,15 @@ func (h *JsonTransport) EncodeResponse(ctx context.Context, w http.ResponseWrite
 		return h.ResponseEncoder(ctx, w, res)
 	}
 
+	forJson, err := writeQueryAndHeader(res, nil, w.Header())
+	if err != nil {
+		return err
+	}
 	encoder := json.NewEncoder(w)
 	if human := ctx.Value(humanType{}); human != nil && human.(bool) {
 		encoder.SetIndent("", "  ")
 	}
-	return encoder.Encode(res)
+	return encoder.Encode(forJson)
 }
 
 type HttpError interface {
@@ -78,18 +93,35 @@ func (h *JsonTransport) EncodeError(ctx context.Context, w http.ResponseWriter, 
 	return jsonError(w, code, "%v", err)
 }
 
-func (h *JsonTransport) EncodeRequest(ctx context.Context, method, url string, req interface{}) (*http.Request, error) {
+func (h *JsonTransport) EncodeRequest(ctx context.Context, method, urlStr string, req interface{}) (*http.Request, error) {
 	if h.RequestEncoder != nil {
-		return h.RequestEncoder(ctx, method, url, req)
+		return h.RequestEncoder(ctx, method, urlStr, req)
 	}
 
-	requestJSON, err := json.Marshal(req)
+	request, err := http.NewRequestWithContext(ctx, method, urlStr, nil)
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(requestJSON))
+	query, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query part of URL: %w", err)
+	}
+	forJson, err := writeQueryAndHeader(req, query, request.Header)
 	if err != nil {
 		return nil, err
+	}
+	request.URL.RawQuery = query.Encode()
+
+	requestJSON, err := json.Marshal(forJson)
+	if err != nil {
+		return nil, err
+	}
+	body := bytes.NewReader(requestJSON)
+	snapshot := *body
+	request.Body = ioutil.NopCloser(body)
+	request.GetBody = func() (io.ReadCloser, error) {
+		r := snapshot
+		return ioutil.NopCloser(&r), nil
 	}
 
 	request.Header.Set("Content-Type", "application/json")
@@ -100,7 +132,15 @@ func (h *JsonTransport) DecodeResponse(ctx context.Context, res *http.Response, 
 	if h.ResponseDecoder != nil {
 		return h.ResponseDecoder(ctx, res, response)
 	}
-	return json.NewDecoder(res.Body).Decode(response)
+
+	if err := json.NewDecoder(res.Body).Decode(response); err != nil {
+		return err
+	}
+	if err := parseQueryAndHeader(response, nil, res.Header); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (h *JsonTransport) DecodeError(ctx context.Context, res *http.Response) error {
@@ -128,4 +168,102 @@ func jsonError(w http.ResponseWriter, code int, format string, args ...interface
 	w.WriteHeader(code)
 	errmsg := fmt.Sprintf(format, args...)
 	return json.NewEncoder(w).Encode(errorMessage{errmsg})
+}
+
+func writeQueryAndHeader(objPtr interface{}, query url.Values, header http.Header) (interface{}, error) {
+	objType := reflect.TypeOf(objPtr).Elem()
+	objValue := reflect.ValueOf(objPtr).Elem()
+	forJson := make(map[string]interface{}, objType.NumField())
+	for i := 0; i < objType.NumField(); i++ {
+		field := objType.Field(i)
+
+		headerKey := field.Tag.Get("header")
+		queryKey := field.Tag.Get("query")
+		if headerKey == "" && (query == nil || queryKey == "") {
+			jsonTag := field.Tag.Get("json")
+			if jsonTag == "-" {
+				continue
+			}
+			parts := strings.SplitN(jsonTag, ",", 2)
+			jsonKey := parts[0]
+			if jsonKey == "" {
+				jsonKey = field.Name
+			}
+			fieldValue := objValue.Field(i)
+			if len(parts) == 2 && parts[1] == "omitempty" {
+				if fieldValue.IsZero() {
+					continue
+				}
+				kind := fieldValue.Kind()
+				if kind == reflect.Array || kind == reflect.Map || kind == reflect.Slice || kind == reflect.String {
+					if fieldValue.Len() == 0 {
+						continue
+					}
+				}
+			}
+			forJson[jsonKey] = fieldValue.Interface()
+			continue
+		}
+
+		fieldObj := objValue.Field(i).Interface()
+		value := ""
+		if marshaler, ok := fieldObj.(encoding.TextMarshaler); ok {
+			valueBytes, err := marshaler.MarshalText()
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal value for field %s: %w", field.Name, err)
+			}
+			value = string(valueBytes)
+		} else {
+			value = fmt.Sprintf("%v", fieldObj)
+		}
+
+		if headerKey != "" {
+			header.Set(headerKey, value)
+		} else if query != nil && queryKey != "" {
+			query.Set(queryKey, value)
+		}
+	}
+	return forJson, nil
+}
+
+func parseQueryAndHeader(objPtr interface{}, query url.Values, header http.Header) error {
+	objType := reflect.TypeOf(objPtr).Elem()
+	objValue := reflect.ValueOf(objPtr).Elem()
+	for i := 0; i < objType.NumField(); i++ {
+		field := objType.Field(i)
+
+		value := ""
+		resetField := false
+		if headerKey := field.Tag.Get("header"); headerKey != "" {
+			value = header.Get(headerKey)
+			resetField = true
+		} else if query != nil {
+			if queryKey := field.Tag.Get("query"); queryKey != "" {
+				value = query.Get(queryKey)
+				resetField = true
+			}
+		}
+		if value == "" {
+			if resetField {
+				// Reset just in case it was provided in JSON.
+				fieldValue := objValue.Field(i)
+				fieldValue.Set(reflect.Zero(fieldValue.Type()))
+			}
+			continue
+		}
+
+		var err error
+		fieldPtr := objValue.Field(i).Addr().Interface()
+		if unmarshaler, ok := fieldPtr.(encoding.TextUnmarshaler); ok {
+			err = unmarshaler.UnmarshalText([]byte(value))
+		} else if fieldStrPtr, ok := fieldPtr.(*string); ok {
+			*fieldStrPtr = value
+		} else {
+			_, err = fmt.Sscanf(value, "%v", fieldPtr)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to parse value %q for field %s: %w", value, field.Name, err)
+		}
+	}
+	return nil
 }

--- a/json_transport_test.go
+++ b/json_transport_test.go
@@ -1,0 +1,310 @@
+package api2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+// CustomType is an integer encoded as a number of "|".
+type CustomType int
+
+func (c CustomType) MarshalText() (text []byte, err error) {
+	return bytes.Repeat([]byte("|"), int(c)), nil
+}
+
+func (c *CustomType) UnmarshalText(text []byte) error {
+	for _, b := range text {
+		if b != '|' {
+			return fmt.Errorf("found unknown characted: %v", b)
+		}
+	}
+	*c = CustomType(len(text))
+	return nil
+}
+
+func TestQueryAndHeader(t *testing.T) {
+	cases := []struct {
+		objPtr      interface{}
+		query       bool
+		wantJson    string
+		wantQuery   url.Values
+		wantHeader  http.Header
+		dontCompare bool // For cases of non-nil empty slice or map.
+	}{
+		{
+			objPtr: &struct {
+				Foo string `json:"foo"`
+			}{
+				Foo: "foo 123",
+			},
+			query:    true,
+			wantJson: `{"foo":"foo 123"}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `query:"foo"`
+			}{
+				Foo: "foo 12\n3",
+			},
+			query: true,
+			wantQuery: map[string][]string{
+				"foo": []string{"foo 12\n3"},
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `header:"foo"`
+			}{
+				Foo: "foo 123",
+			},
+			wantHeader: map[string][]string{
+				"Foo": []string{"foo 123"},
+			},
+			wantJson: `{}`,
+		},
+
+		{
+			objPtr: &struct {
+				Foo string `json:"foo"`
+				Bar int    `query:"bar"`
+				Baz bool   `header:"baz"`
+			}{
+				Foo: "foo!",
+				Bar: 100,
+				Baz: true,
+			},
+			query:    true,
+			wantJson: `{"foo":"foo!"}`,
+			wantQuery: map[string][]string{
+				"bar": []string{"100"},
+			},
+			wantHeader: map[string][]string{
+				"Baz": []string{"true"},
+			},
+		},
+		{
+			objPtr: &struct {
+				Bar int  `query:"bar"`
+				Baz bool `header:"baz"`
+			}{
+				Bar: 100,
+				Baz: true,
+			},
+			query:    true,
+			wantJson: `{}`,
+			wantQuery: map[string][]string{
+				"bar": []string{"100"},
+			},
+			wantHeader: map[string][]string{
+				"Baz": []string{"true"},
+			},
+		},
+
+		{
+			objPtr: &struct {
+				Foo int16 `query:"foo"`
+			}{
+				Foo: -30,
+			},
+			query:    true,
+			wantJson: `{}`,
+			wantQuery: map[string][]string{
+				"foo": []string{"-30"},
+			},
+		},
+		{
+			objPtr: &struct {
+				Foo bool `query:"foo"`
+			}{
+				Foo: false,
+			},
+			query:    true,
+			wantJson: `{}`,
+			wantQuery: map[string][]string{
+				"foo": []string{"false"},
+			},
+		},
+
+		{
+			objPtr: &struct {
+				Foo CustomType `query:"foo"`
+			}{
+				Foo: CustomType(5),
+			},
+			query:    true,
+			wantJson: `{}`,
+			wantQuery: map[string][]string{
+				"foo": []string{"|||||"},
+			},
+		},
+
+		{
+			objPtr: &struct {
+				Foo string `json:"foo"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{"foo":""}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"foo,omitempty"`
+			}{
+				Foo: "123",
+			},
+			wantJson: `{"foo":"123"}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"foo,omitempty"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo int `json:"foo,omitempty"`
+			}{
+				Foo: 0,
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo bool `json:"foo,omitempty"`
+			}{
+				Foo: false,
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo []int `json:"foo,omitempty"`
+			}{
+				Foo: nil,
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo []int `json:"foo,omitempty"`
+			}{
+				Foo: []int{},
+			},
+			wantJson:    `{}`,
+			dontCompare: true,
+		},
+		{
+			objPtr: &struct {
+				Foo map[string]int `json:"foo,omitempty"`
+			}{
+				Foo: nil,
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo map[string]int `json:"foo,omitempty"`
+			}{
+				Foo: map[string]int{},
+			},
+			wantJson:    `{}`,
+			dontCompare: true,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:",omitempty"`
+			}{
+				Foo: "aaa",
+			},
+			wantJson: `{"Foo":"aaa"}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:",omitempty"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"-"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"-,"`
+			}{
+				Foo: "ggg",
+			},
+			wantJson: `{"-":"ggg"}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"-,"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{"-":""}`,
+		},
+		{
+			objPtr: &struct {
+				Foo string `json:"-,omitempty"`
+			}{
+				Foo: "",
+			},
+			wantJson: `{}`,
+		},
+	}
+
+	for i, tc := range cases {
+		var query url.Values
+		if tc.query {
+			query = make(url.Values)
+		}
+		header := make(http.Header)
+
+		forJson, err := writeQueryAndHeader(tc.objPtr, query, header)
+		if err != nil {
+			t.Errorf("case %d: writeQueryAndHeader failed: %v", i, err)
+		}
+		jsonBytes, err := json.Marshal(forJson)
+		if err != nil {
+			t.Errorf("case %d: json.Marshal failed: %v", i, err)
+		}
+
+		jsonStr := string(jsonBytes)
+		if jsonStr != tc.wantJson {
+			t.Errorf("case %d: got json %s, want %s", i, jsonStr, tc.wantJson)
+		}
+		if tc.query && tc.wantQuery != nil && !reflect.DeepEqual(query, tc.wantQuery) {
+			t.Errorf("case %d: query does not match, got %#v, want %#v", i, query, tc.wantQuery)
+		}
+		if tc.wantHeader != nil && !reflect.DeepEqual(header, tc.wantHeader) {
+			t.Errorf("case %d: header does not match, got %#v, want %#v", i, header, tc.wantHeader)
+		}
+
+		objPtr2 := reflect.New(reflect.TypeOf(tc.objPtr).Elem()).Interface()
+		if err := json.Unmarshal(jsonBytes, objPtr2); err != nil {
+			t.Errorf("case %d: json.Unmarshal failed: %v", i, err)
+		}
+		if err := parseQueryAndHeader(objPtr2, query, header); err != nil {
+			t.Errorf("case %d: parseQueryAndHeader failed: %v", i, err)
+		}
+
+		if !tc.dontCompare && !reflect.DeepEqual(objPtr2, tc.objPtr) {
+			t.Errorf("case %d: decoded object is not equal to source object: %#v != %#v", i, objPtr2, tc.objPtr)
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -42,6 +42,10 @@ func BindRoutes(mux *http.ServeMux, routes []Route, opts ...Option) {
 }
 
 func newHTTPHandler(h interface{}, t Transport, errorf func(format string, args ...interface{})) http.HandlerFunc {
+	if t == nil {
+		t = DefaultTransport
+	}
+
 	if m, ok := h.(*interfaceMethod); ok {
 		h = m.Func()
 	}

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -42,8 +42,8 @@ func TestAPI(t *testing.T) {
 	}
 
 	routes := []api2.Route{
-		{Method: http.MethodGet, Path: "/number", Handler: getHandler, Transport: &api2.JsonTransport{}},
-		{Method: http.MethodPost, Path: "/number", Handler: postHandler, Transport: &api2.JsonTransport{}},
+		{Method: http.MethodGet, Path: "/number", Handler: getHandler},
+		{Method: http.MethodPost, Path: "/number", Handler: postHandler},
 	}
 
 	mux := http.NewServeMux()

--- a/test/api_test.go
+++ b/test/api_test.go
@@ -100,3 +100,62 @@ func TestAPI(t *testing.T) {
 		t.Errorf("GET(42) returned %d, want %d.", getRes.DoubleNumber, 84)
 	}
 }
+
+func TestQueryAndHeader(t *testing.T) {
+	type PostRequest struct {
+		JsonField    int `json:"json_field"`
+		QueryField   int `query:"query_field"`
+		HeaderField  int `header:"query_field"`
+		SkippedField int `json:"-"`
+	}
+	type PostResponse struct {
+		JsonField    int `json:"json_field"`
+		HeaderField  int `header:"query_field"`
+		SkippedField int `json:"-"`
+	}
+
+	postHandler := func(ctx context.Context, req *PostRequest) (res *PostResponse, err error) {
+		if req.SkippedField != 0 {
+			return nil, fmt.Errorf("SkippedField=%d, want 0", req.SkippedField)
+		}
+		return &PostResponse{
+			JsonField:    req.JsonField,
+			HeaderField:  req.QueryField + req.HeaderField,
+			SkippedField: 5,
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodPost, Path: "/number", Handler: postHandler, Transport: &api2.JsonTransport{}},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := api2.NewClient(routes, server.URL)
+
+	ctx := context.Background()
+
+	postRes := &PostResponse{}
+	err := client.Call(ctx, postRes, &PostRequest{
+		JsonField:    1,
+		QueryField:   2,
+		HeaderField:  3,
+		SkippedField: 4,
+	})
+	if err != nil {
+		t.Errorf("POST failed: %v.", err)
+	}
+
+	if postRes.JsonField != 1 {
+		t.Errorf("JsonField=%d, want 1", postRes.JsonField)
+	}
+	if postRes.HeaderField != 2+3 {
+		t.Errorf("HeaderField=%d, want %d", postRes.HeaderField, 2+3)
+	}
+	if postRes.SkippedField != 0 {
+		t.Errorf("SkippedField=%d, want 0", postRes.SkippedField)
+	}
+}

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -1,0 +1,62 @@
+package api2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/starius/api2"
+)
+
+func BenchmarkAPI(b *testing.B) {
+	type PostRequest struct {
+		Foo    int    `json:"foo"`
+		Bar    string `json:"bar"`
+		Baz    []int  `json:"baz"`
+		PageID string `json:"page_id"`
+	}
+	type PostResponse struct {
+		Counters   map[string]int `json:"counters"`
+		NextPageID string         `json:"next_page_id"`
+	}
+
+	postHandler := func(ctx context.Context, req *PostRequest) (res *PostResponse, err error) {
+		counters := make(map[string]int, len(req.Baz))
+		for i, count := range req.Baz {
+			counters[strconv.Itoa(i)] = count
+		}
+		return &PostResponse{
+			Counters:   counters,
+			NextPageID: req.PageID + "1",
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodPost, Path: "/number", Handler: postHandler, Transport: &api2.JsonTransport{}},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := api2.NewClient(routes, server.URL)
+
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		postReq := &PostRequest{
+			Foo:    123,
+			Bar:    "bar bar bar",
+			Baz:    []int{10, 30, 25, 0},
+			PageID: "page-4cdab3",
+		}
+		postRes := &PostResponse{}
+		err := client.Call(ctx, postRes, postReq)
+		if err != nil {
+			b.Errorf("POST failed: %v.", err)
+		}
+	}
+}

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -34,7 +34,7 @@ func BenchmarkAPI(b *testing.B) {
 	}
 
 	routes := []api2.Route{
-		{Method: http.MethodPost, Path: "/number", Handler: postHandler, Transport: &api2.JsonTransport{}},
+		{Method: http.MethodPost, Path: "/number", Handler: postHandler},
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
Performance:
```
json-minus
BenchmarkAPI-3             77253            143875 ns/op

master (f3eb4e4335)
BenchmarkAPI-3             64728            174644 ns/op

query-and-header
BenchmarkAPI-3             90836            153767 ns/op
```

No idea why json-minus is faster than master. Anyway, this PR does not bring any significant slowdown which is good,