### PR TITLE
json_transport: add support of use_as_body tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ but passed as is. Types implementing `encoding.TextMarshaler` and
 `encoding.TextUnmarshaler` are encoded and decoded using it.
 If no field is no JSON field in the struct, then HTTP body is skipped.
 
+If you need the top-level type matching body JSON to be not a struct,
+but of some other kind (e.g. slice or map), you should provide a field
+in your struct with tag `use_as_body:"true"`:
+
+```go
+type FooRequest struct {
+	// Body of the request is JSON array of strings: ["abc", "eee", ...].
+	Body []string `use_as_body:"true"`
+
+	// You can add 'header' and 'query' fields here, but not 'json'.
+}
+```
+
 Now let's write the function that generates the table of routes:
 
 ```go

--- a/doc.go
+++ b/doc.go
@@ -50,6 +50,17 @@ but passed as is. Types implementing encoding.TextMarshaler and
 encoding.TextUnmarshaler are encoded and decoded using it.
 If no field is no JSON field in the struct, then HTTP body is skipped.
 
+If you need the top-level type matching body JSON to be not a struct,
+but of some other kind (e.g. slice or map), you should provide a field
+in your struct with tag `use_as_body:"true"`:
+
+	type FooRequest struct {
+		// Body of the request is JSON array of strings: ["abc", "eee", ...].
+		Body []string `use_as_body:"true"`
+
+		// You can add 'header' and 'query' fields here, but not 'json'.
+	}
+
 Now let's write the function that generates the table of routes:
 
 	func GetRoutes(s *Foo) []api2.Route {

--- a/json_transport.go
+++ b/json_transport.go
@@ -313,7 +313,6 @@ func parseRequest(objPtr interface{}, jsonReader io.Reader, query url.Values, he
 	} else if len(p.QueryMapping)+len(p.HeaderMapping) == objType.NumField() {
 		// All the fields are query or header. No fields for JSON.
 		// In this case JSON parsing is skipped.
-		io.Copy(ioutil.Discard, jsonReader)
 	} else if len(p.QueryMapping) == 0 && len(p.HeaderMapping) == 0 {
 		// No query and header. Parse JSON into the original structure.
 		if err := json.NewDecoder(jsonReader).Decode(objPtr); err != nil {
@@ -331,6 +330,9 @@ func parseRequest(objPtr interface{}, jsonReader io.Reader, query url.Values, he
 			objValue.Field(m.OrigField).Set(jsonValue.Field(m.JsonField))
 		}
 	}
+
+	// Drain the reader in case we skipped parsing or something is left.
+	io.Copy(ioutil.Discard, jsonReader)
 
 	for _, m := range p.QueryMapping {
 		fieldPtr := objValue.Field(m.Field).Addr().Interface()

--- a/json_transport.go
+++ b/json_transport.go
@@ -180,15 +180,19 @@ type preparedType struct {
 	HeaderMapping []strMapping
 	JsonMapping   []intMapping
 	TypeForJson   reflect.Type
+	BodyField     int
 }
 
+const noBodyField = -1
+
 func prepare(objType reflect.Type) *preparedType {
-	p := &preparedType{}
+	p := &preparedType{BodyField: noBodyField}
 	jsonFields := make([]reflect.StructField, 0, objType.NumField())
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)
 		queryKey := field.Tag.Get("query")
 		headerKey := field.Tag.Get("header")
+		isBodyField := field.Tag.Get("use_as_body") == "true"
 		if queryKey != "" {
 			p.QueryMapping = append(p.QueryMapping, strMapping{
 				Field: i,
@@ -199,6 +203,8 @@ func prepare(objType reflect.Type) *preparedType {
 				Field: i,
 				Key:   headerKey,
 			})
+		} else if isBodyField {
+			p.BodyField = i
 		} else {
 			// Add to JSON.
 			p.JsonMapping = append(p.JsonMapping, intMapping{
@@ -208,7 +214,9 @@ func prepare(objType reflect.Type) *preparedType {
 			jsonFields = append(jsonFields, field)
 		}
 	}
-	p.TypeForJson = reflect.StructOf(jsonFields)
+	if p.BodyField == noBodyField {
+		p.TypeForJson = reflect.StructOf(jsonFields)
+	}
 	return p
 }
 
@@ -247,16 +255,24 @@ func writeQueryAndHeader(objPtr interface{}, query url.Values, header http.Heade
 	}
 	p := p0.(*preparedType)
 
-	if len(p.QueryMapping) == 0 && len(p.HeaderMapping) == 0 {
+	objValue := reflect.ValueOf(objPtr).Elem()
+
+	var jsonPtr interface{}
+	if p.BodyField != noBodyField {
+		// 'use_as_body' case.
+		jsonPtr = objValue.Field(p.BodyField).Addr().Interface()
+	} else if len(p.QueryMapping) == 0 && len(p.HeaderMapping) == 0 {
 		// No query and header. Returning the original object.
-		return objPtr, nil
+		jsonPtr = objPtr
+	} else {
+		// JSON fields mixed with header and/or query fields.
+		forJson := reflect.New(p.TypeForJson).Elem()
+		for _, m := range p.JsonMapping {
+			forJson.Field(m.JsonField).Set(objValue.Field(m.OrigField))
+		}
+		jsonPtr = forJson.Addr().Interface()
 	}
 
-	objValue := reflect.ValueOf(objPtr).Elem()
-	forJson := reflect.New(p.TypeForJson).Elem()
-	for _, m := range p.JsonMapping {
-		forJson.Field(m.JsonField).Set(objValue.Field(m.OrigField))
-	}
 	for _, m := range p.QueryMapping {
 		value, err := toString(objValue.Field(m.Field).Interface())
 		if err != nil {
@@ -274,7 +290,7 @@ func writeQueryAndHeader(objPtr interface{}, query url.Values, header http.Heade
 		header.Set(m.Key, value)
 	}
 
-	return forJson.Addr().Interface(), nil
+	return jsonPtr, nil
 }
 
 func parseRequest(objPtr interface{}, jsonReader io.Reader, query url.Values, header http.Header) error {
@@ -288,14 +304,23 @@ func parseRequest(objPtr interface{}, jsonReader io.Reader, query url.Values, he
 
 	objValue := reflect.ValueOf(objPtr).Elem()
 
-	if len(p.QueryMapping)+len(p.HeaderMapping) == objType.NumField() {
+	if p.BodyField != noBodyField {
+		// 'use_as_body' case.
+		jsonPtr := objValue.Field(p.BodyField).Addr().Interface()
+		if err := json.NewDecoder(jsonReader).Decode(jsonPtr); err != nil {
+			return err
+		}
+	} else if len(p.QueryMapping)+len(p.HeaderMapping) == objType.NumField() {
 		// All the fields are query or header. No fields for JSON.
 		// In this case JSON parsing is skipped.
 		io.Copy(ioutil.Discard, jsonReader)
 	} else if len(p.QueryMapping) == 0 && len(p.HeaderMapping) == 0 {
 		// No query and header. Parse JSON into the original structure.
-		return json.NewDecoder(jsonReader).Decode(objPtr)
+		if err := json.NewDecoder(jsonReader).Decode(objPtr); err != nil {
+			return err
+		}
 	} else {
+		// JSON fields mixed with header and/or query fields.
 		// Parse JSON into a temporary struct and copy fields into the original struct.
 		jsonPtrValue := reflect.New(p.TypeForJson)
 		if err := json.NewDecoder(jsonReader).Decode(jsonPtrValue.Interface()); err != nil {

--- a/json_transport.go
+++ b/json_transport.go
@@ -54,6 +54,8 @@ func (h *JsonTransport) EncodeResponse(ctx context.Context, w http.ResponseWrite
 		return h.ResponseEncoder(ctx, w, res)
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
 	forJson, err := writeQueryAndHeader(res, nil, w.Header())
 	if err != nil {
 		return err
@@ -122,7 +124,8 @@ func (h *JsonTransport) EncodeRequest(ctx context.Context, method, urlStr string
 		return ioutil.NopCloser(&r), nil
 	}
 
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	request.Header.Set("Accept", "application/json")
 	return request, nil
 }
 

--- a/json_transport_test.go
+++ b/json_transport_test.go
@@ -32,6 +32,12 @@ func TestQueryAndHeader(t *testing.T) {
 		Foo string `json:"foo"`
 	}
 
+	type Person struct {
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Age       int    `json:"age"`
+	}
+
 	cases := []struct {
 		objPtr      interface{}
 		query       bool
@@ -320,6 +326,113 @@ func TestQueryAndHeader(t *testing.T) {
 				},
 			},
 			wantJson: `{"foo":"aaa"}`,
+		},
+
+		{
+			objPtr: &struct {
+				Body []int `use_as_body:"true"`
+			}{
+				Body: []int{1, 2, 3},
+			},
+			wantJson: `[1,2,3]`,
+		},
+		{
+			objPtr: &struct {
+				Body map[string]int `use_as_body:"true"`
+			}{
+				Body: map[string]int{
+					"key1": 100,
+					"key2": 200,
+				},
+			},
+			wantJson: `{"key1":100,"key2":200}`,
+		},
+		{
+			objPtr: &struct {
+				Body       map[string]int `use_as_body:"true"`
+				ExtraField string
+			}{
+				Body: map[string]int{
+					"key1": 100,
+					"key2": 200,
+				},
+			},
+			wantJson: `{"key1":100,"key2":200}`,
+		},
+		{
+			objPtr: &struct {
+				Body []int `use_as_body:"true"`
+				Bar  int   `query:"bar"`
+				Baz  bool  `header:"baz"`
+			}{
+				Body: []int{1, 2, 3},
+				Bar:  500,
+				Baz:  true,
+			},
+			wantJson: `[1,2,3]`,
+			query:    true,
+		},
+		{
+			objPtr: &struct {
+				Body       []int `use_as_body:"true"`
+				Bar        int   `query:"bar"`
+				Baz        bool  `header:"baz"`
+				ExtraField string
+			}{
+				Body: []int{1, 2, 3},
+				Bar:  500,
+				Baz:  true,
+			},
+			wantJson: `[1,2,3]`,
+			query:    true,
+		},
+		{
+			objPtr: &struct {
+				Body []Person `use_as_body:"true"`
+			}{
+				Body: []Person{
+					{FirstName: "Ivan", LastName: "Ivanov", Age: 55},
+					{FirstName: "Petr", LastName: "Petrov", Age: 75},
+				},
+			},
+			wantJson: `[{"first_name":"Ivan","last_name":"Ivanov","age":55},{"first_name":"Petr","last_name":"Petrov","age":75}]`,
+		},
+		{
+			objPtr: &struct {
+				Body []Person `use_as_body:"true"`
+				Bar  int      `query:"bar"`
+				Baz  bool     `header:"baz"`
+			}{
+				Body: []Person{
+					{FirstName: "Ivan", LastName: "Ivanov", Age: 55},
+					{FirstName: "Petr", LastName: "Petrov", Age: 75},
+				},
+				Bar: 500,
+				Baz: true,
+			},
+			wantJson: `[{"first_name":"Ivan","last_name":"Ivanov","age":55},{"first_name":"Petr","last_name":"Petrov","age":75}]`,
+			query:    true,
+		},
+		{
+			objPtr: &struct {
+				Body map[string]Person `use_as_body:"true"`
+			}{
+				Body: map[string]Person{
+					"ivan.ivanov": {FirstName: "Ivan", LastName: "Ivanov", Age: 55},
+				},
+			},
+			wantJson: `{"ivan.ivanov":{"first_name":"Ivan","last_name":"Ivanov","age":55}}`,
+		},
+		{
+			objPtr: &struct {
+				Body       map[string]Person `use_as_body:"true"`
+				ExtraField string
+			}{
+				Body: map[string]Person{
+					"ivan.ivanov": {FirstName: "Ivan", LastName: "Ivanov", Age: 55},
+				},
+			},
+			wantJson: `{"ivan.ivanov":{"first_name":"Ivan","last_name":"Ivanov","age":55}}`,
 		},
 	}
 


### PR DESCRIPTION
It is used to make the whole request or response an array or a map
which is required by some existing APIs.