### PR TITLE
json_transport: add support of protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ type FooRequest struct {
 }
 ```
 
+If you use `use_as_body:"true"`, you can also set `is_protobuf:"true"`
+and put a protobuf type (convertible to proto.Message) in that field.
+It will be sent over wire as protobuf binary form.
+
 Now let's write the function that generates the table of routes:
 
 ```go
@@ -168,6 +172,7 @@ $ go get github.com/starius/api2/example/...
 $ server &
 $ client
 test
+87672h0m0s
 ```
 
 Code generation code is located in directory [example/gen](./example/gen).

--- a/api.go
+++ b/api.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"path"
 	"reflect"
+
+	"google.golang.org/protobuf/proto"
 )
 
 // Route describes one endpoint in the API, associated with particular
@@ -78,15 +80,26 @@ func validateHandler(handlerType reflect.Type) {
 	}
 }
 
+var protoType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+
 func validateRequestResponse(structType reflect.Type, request bool) {
 	var jsonFields, bodyFields []string
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
 		hasJson := field.Tag.Get("json") != ""
 		hasUseAsBody := field.Tag.Get("use_as_body") == "true"
+		hasProtobuf := field.Tag.Get("is_protobuf") == "true"
 		hasQuery := field.Tag.Get("query") != ""
 		hasHeader := field.Tag.Get("header") != ""
 		hasCookie := field.Tag.Get("cookie") != ""
+
+		if hasProtobuf && !hasUseAsBody {
+			panic(fmt.Sprintf("field %s of struct %s: hasProtobuf=%v, so hasUseAsBody must also be %v", field.Name, structType.Name(), hasProtobuf, hasUseAsBody))
+		}
+		if hasProtobuf && !field.Type.ConvertibleTo(protoType) {
+			panic(fmt.Sprintf("field %s of struct %s: hasProtobuf=%v, but its type %s is not convertible to proto.Message", field.Name, structType.Name(), hasProtobuf, field.Type))
+		}
+
 		sum := 0
 		for _, v := range []bool{hasJson, hasUseAsBody, hasQuery, hasHeader, hasCookie} {
 			if v {

--- a/api_test.go
+++ b/api_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestValidateRequestResponse(t *testing.T) {
@@ -62,6 +65,7 @@ func TestValidateRequestResponse(t *testing.T) {
 			request:   false,
 			wantPanic: true,
 		},
+
 		{
 			obj: struct {
 				Foo string `json:"foo" query:"foo"`
@@ -114,6 +118,49 @@ func TestValidateRequestResponse(t *testing.T) {
 		{
 			obj: struct {
 				Foo string `json:"foo" header:"foo" query:"foo" cookie:"foo"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+
+		{
+			obj: struct {
+				Foo *timestamppb.Timestamp `use_as_body:"true" is_protobuf:"true"`
+			}{},
+			request:   true,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				Foo *timestamppb.Timestamp `use_as_body:"true" is_protobuf:"true"`
+			}{},
+			request:   false,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				AnyProtobuf proto.Message `use_as_body:"true" is_protobuf:"true"`
+			}{},
+			request:   true,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				AnyProtobuf proto.Message `use_as_body:"true" is_protobuf:"true"`
+			}{},
+			request:   false,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				Foo string `use_as_body:"true" is_protobuf:"true"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo *timestamppb.Timestamp `is_protobuf:"true"`
 			}{},
 			request:   true,
 			wantPanic: true,

--- a/doc.go
+++ b/doc.go
@@ -64,6 +64,10 @@ in your struct with tag `use_as_body:"true"`:
 		// You can add 'header', 'query' and 'cookie' fields here, but not 'json'.
 	}
 
+If you use `use_as_body:"true"`, you can also set `is_protobuf:"true"`
+and put a protobuf type (convertible to proto.Message) in that field.
+It will be sent over wire as protobuf binary form.
+
 Now let's write the function that generates the table of routes:
 
 	func GetRoutes(s *Foo) []api2.Route {

--- a/example/client.go
+++ b/example/client.go
@@ -43,3 +43,12 @@ func (c *Client) Echo(ctx context.Context, req *EchoRequest) (res *EchoResponse,
 	}
 	return
 }
+
+func (c *Client) Since(ctx context.Context, req *SinceRequest) (res *SinceResponse, err error) {
+	res = &SinceResponse{}
+	err = c.api2client.Call(ctx, res, req)
+	if err != nil {
+		return nil, err
+	}
+	return
+}

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/starius/api2/example"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func main() {
@@ -29,6 +31,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
 	fmt.Println(echoRes.Text)
+
+	sinceRes, err := client.Since(ctx, &example.SinceRequest{
+		Session: helloRes.Session,
+		Body:    timestamppb.New(time.Date(2020, time.July, 10, 11, 30, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(sinceRes.Body.AsDuration())
 }

--- a/example/echo_service.go
+++ b/example/echo_service.go
@@ -5,6 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type EchoRepository struct {
@@ -59,5 +62,17 @@ func (s *EchoService) Echo(ctx context.Context, req *EchoRequest) (*EchoResponse
 	}
 	return &EchoResponse{
 		Text: req.Text,
+	}, nil
+}
+
+func (s *EchoService) Since(ctx context.Context, req *SinceRequest) (*SinceResponse, error) {
+	if !s.sessions[req.Session] {
+		return nil, fmt.Errorf("bad session")
+	}
+	t1 := time.Date(2010, time.July, 10, 11, 30, 0, 0, time.UTC)
+	t2 := req.Body.AsTime()
+	duration := t2.Sub(t1)
+	return &SinceResponse{
+		Body: durationpb.New(duration),
 	}, nil
 }

--- a/example/openapi/openapi.json
+++ b/example/openapi/openapi.json
@@ -83,6 +83,17 @@
     ],
     "type": "number"
    },
+   "example.SinceRequest": {
+    "properties": {
+     "session": {
+      "type": "string"
+     }
+    },
+    "type": "object"
+   },
+   "example.SinceResponse": {
+    "type": "object"
+   },
    "example.UserSettings": {}
   },
   "requestBodies": {
@@ -100,6 +111,15 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/example.HelloRequest"
+      }
+     }
+    }
+   },
+   "example.SinceRequest": {
+    "content": {
+     "application/json": {
+      "schema": {
+       "$ref": "#/components/schemas/example.SinceRequest"
       }
      }
     }
@@ -147,6 +167,31 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/example.HelloResponse"
+        }
+       }
+      },
+      "description": "info"
+     },
+     "default": {
+      "description": ""
+     }
+    },
+    "tags": [
+     "example"
+    ]
+   }
+  },
+  "/since": {
+   "post": {
+    "requestBody": {
+     "$ref": "#/components/requestBodies/example.SinceRequest"
+    },
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/example.SinceResponse"
         }
        }
       },

--- a/example/routes.go
+++ b/example/routes.go
@@ -10,5 +10,6 @@ func GetRoutes(s IEchoService) []api2.Route {
 	return []api2.Route{
 		{Method: http.MethodPost, Path: "/hello", Handler: api2.Method(&s, "Hello")},
 		{Method: http.MethodPost, Path: "/echo", Handler: api2.Method(&s, "Echo")},
+		{Method: http.MethodPost, Path: "/since", Handler: api2.Method(&s, "Since")},
 	}
 }

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -15,6 +15,10 @@ example: {
 				"POST", "/echo",
 				{"header":["session"],"json":["text","bar","code","dir","items","maps"]},
 				{"json":["text"]}),
+			Since: route<example.SinceRequest, example.SinceResponse>(
+				"POST", "/since",
+				{"header":["session"]},
+				{}),
 	},
 },
 }
@@ -65,6 +69,15 @@ export type UserSettings = Record<string, any> |  null
 // EchoResponse.
 export type EchoResponse = {
 	text: string // field comment.
+}
+
+
+export type SinceRequest = {
+	session?: string
+}
+
+
+export type SinceResponse = {
 }
 
 

--- a/example/types.go
+++ b/example/types.go
@@ -5,6 +5,9 @@ package example
 import (
 	"context"
 	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Direction int
@@ -59,7 +62,17 @@ type HelloResponse struct {
 	Session string `header:"session"`
 }
 
+type SinceRequest struct {
+	Session string                 `header:"session"`
+	Body    *timestamppb.Timestamp `use_as_body:"true" is_protobuf:"true"`
+}
+
+type SinceResponse struct {
+	Body *durationpb.Duration `use_as_body:"true" is_protobuf:"true"`
+}
+
 type IEchoService interface {
 	Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error)
 	Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error)
+	Since(ctx context.Context, req *SinceRequest) (*SinceResponse, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.9.5
 	golang.org/x/tools v0.0.0-20191114200427-caa0b0f7d508
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,11 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1QAp/SlnNrZhI=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -73,6 +76,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191114200427-caa0b0f7d508 h1:0FYNp0PF9kFm/ZUrvcJiQ12IUJJG7iAc6Cu01wbKrbU=
 golang.org/x/tools v0.0.0-20191114200427-caa0b0f7d508/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -83,6 +87,9 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/protobuf_test.go
+++ b/test/protobuf_test.go
@@ -1,0 +1,57 @@
+package api2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/starius/api2"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestProtobuf(t *testing.T) {
+	type ProtoRequest struct {
+		Body *durationpb.Duration `use_as_body:"true" is_protobuf:"true"`
+	}
+	type ProtoResponse struct {
+		Body *timestamppb.Timestamp `use_as_body:"true" is_protobuf:"true"`
+	}
+
+	t1 := time.Date(2020, time.July, 10, 11, 30, 0, 0, time.UTC)
+
+	protoHandler := func(ctx context.Context, req *ProtoRequest) (res *ProtoResponse, err error) {
+		// Add passed duration to t1 and pass result back.
+		duration := req.Body.AsDuration()
+		t2 := t1.Add(duration)
+		return &ProtoResponse{
+			Body: timestamppb.New(t2),
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodPost, Path: "/proto", Handler: protoHandler},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := api2.NewClient(routes, server.URL)
+
+	protoRes := &ProtoResponse{}
+	err := client.Call(context.Background(), protoRes, &ProtoRequest{
+		Body: durationpb.New(time.Second),
+	})
+	if err != nil {
+		t.Errorf("request with protobuf failed: %v.", err)
+	}
+	got := protoRes.Body.AsTime().Format("2006-01-02 15:04:05")
+	want := "2020-07-10 11:30:01"
+	if got != want {
+		t.Errorf("request with protobuf returned %q, want %q", got, want)
+	}
+}

--- a/ts_client.go
+++ b/ts_client.go
@@ -163,20 +163,22 @@ func serializeTypeInfo(t *preparedType) ([]byte, error) {
 	for _, v := range t.QueryMapping {
 		res.Query = append(res.Query, v.Key)
 	}
-	for i := 0; i < t.TypeForJson.NumField(); i++ {
-		ft := t.TypeForJson.Field(i)
-		tag, err := typegen.ParseStructTag(ft.Tag)
-		if err != nil {
-			return nil, err
+	if t.TypeForJson != nil {
+		for i := 0; i < t.TypeForJson.NumField(); i++ {
+			ft := t.TypeForJson.Field(i)
+			tag, err := typegen.ParseStructTag(ft.Tag)
+			if err != nil {
+				return nil, err
+			}
+			if tag.State == typegen.Ignored || tag.State == typegen.NoInfo {
+				continue
+			}
+			name := ft.Name
+			if tag.FieldName != "" {
+				name = tag.FieldName
+			}
+			res.Json = append(res.Json, name)
 		}
-		if tag.State == typegen.Ignored || tag.State == typegen.NoInfo {
-			continue
-		}
-		name := ft.Name
-		if tag.FieldName != "" {
-			name = tag.FieldName
-		}
-		res.Json = append(res.Json, name)
 	}
 	return json.Marshal(res)
 }


### PR DESCRIPTION
Whole request/response can be a protobuf message instead of JSON.

If you use `use_as_body:"true"`, you can also set `is_protobuf:"true"`
and put a protobuf type (convertible to proto.Message) in that field.
It will be sent over wire as protobuf binary form.