### PR TITLE
add option MaxBody, default to 10MB

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ type Client struct {
 	baseURL       string
 	errorf        func(format string, args ...interface{})
 	authorization string
+	maxBody       int64
 }
 
 type signature struct {
@@ -67,6 +68,7 @@ func NewClient(routes []Route, baseURL string, opts ...Option) *Client {
 		baseURL:       baseURL,
 		errorf:        config.errorf,
 		authorization: config.authorization,
+		maxBody:       config.maxBody,
 	}
 }
 
@@ -104,6 +106,7 @@ func (c *Client) Call(ctx context.Context, response, request interface{}) error 
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
+	res.Body = http.MaxBytesReader(nil, res.Body, c.maxBody)
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			c.errorf("failed to close resource: %v", err)

--- a/options.go
+++ b/options.go
@@ -9,11 +9,15 @@ type Config struct {
 	errorf        func(format string, args ...interface{})
 	authorization string // Affects only clients.
 	client        *http.Client
+	maxBody       int64
 }
+
+const defaultMaxBody = 10 * 1024 * 1024
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		errorf: log.Printf,
+		errorf:  log.Printf,
+		maxBody: defaultMaxBody,
 	}
 }
 
@@ -34,5 +38,11 @@ func AuthorizationHeader(authorization string) Option {
 func CustomClient(client *http.Client) Option {
 	return func(config *Config) {
 		config.client = client
+	}
+}
+
+func MaxBody(maxBody int64) Option {
+	return func(config *Config) {
+		config.maxBody = maxBody
 	}
 }

--- a/server.go
+++ b/server.go
@@ -50,6 +50,7 @@ func BindRoutes(mux *http.ServeMux, routes []Route, opts ...Option) {
 				}
 				return
 			}
+			r.Body = http.MaxBytesReader(w, r.Body, config.maxBody)
 			handler(w, r)
 		})
 	}

--- a/test/max_body_test.go
+++ b/test/max_body_test.go
@@ -1,0 +1,93 @@
+package api2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/starius/api2"
+)
+
+func TestMaxBody(t *testing.T) {
+	type Request struct {
+		Foo string `json:"foo"`
+	}
+	type Response struct {
+		Bar string `json:"bar"`
+	}
+
+	const size = 1000
+
+	handler := func(ctx context.Context, req *Request) (res *Response, err error) {
+		return &Response{
+			Bar: string(make([]byte, size)),
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodPost, Path: "/handle", Handler: handler},
+	}
+
+	t.Run("no maxBody (control)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		api2.BindRoutes(mux, routes)
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		client := api2.NewClient(routes, server.URL)
+
+		res := &Response{}
+		err := client.Call(context.Background(), res, &Request{
+			Foo: string(make([]byte, size)),
+		})
+		if err != nil {
+			t.Errorf("request failed: %v.", err)
+		}
+		if len(res.Bar) != size {
+			t.Errorf("wrong bar size: got %d, want %d", len(res.Bar), size)
+		}
+	})
+
+	t.Run("maxBody in server", func(t *testing.T) {
+		mux := http.NewServeMux()
+		api2.BindRoutes(mux, routes, api2.MaxBody(size/2))
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		client := api2.NewClient(routes, server.URL)
+
+		res := &Response{}
+		err := client.Call(context.Background(), res, &Request{
+			Foo: string(make([]byte, size)),
+		})
+		if err == nil {
+			t.Errorf("request had to fail, but passed")
+		}
+		wantMessage := "API returned error with HTTP status 400 Bad Request: failed to parse request: http: request body too large"
+		if err.Error() != wantMessage {
+			t.Errorf("request failed with unexpected error: got %q, want %q", err.Error(), wantMessage)
+		}
+	})
+
+	t.Run("maxBody in client", func(t *testing.T) {
+		mux := http.NewServeMux()
+		api2.BindRoutes(mux, routes)
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		client := api2.NewClient(routes, server.URL, api2.MaxBody(size/2))
+
+		res := &Response{}
+		err := client.Call(context.Background(), res, &Request{
+			Foo: string(make([]byte, size)),
+		})
+		if err == nil {
+			t.Errorf("request had to fail, but passed")
+		}
+		wantMessage := "http: request body too large"
+		if err.Error() != wantMessage {
+			t.Errorf("request failed with unexpected error: got %q, want %q", err.Error(), wantMessage)
+		}
+	})
+}


### PR DESCRIPTION
This is a breaking change if your server or client accepts
request or response body from another side of size > 10MB.
In this case pass the following option to BindRoutes/NewClient:
api2.MaxBody(desired max body size).