### PR TITLE
support streaming HTTP body

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ To build and run it:
 
 ```
 $ go get github.com/starius/api2/example/...
-$ server &
+$ app &
 $ client
 test
 87672h0m0s

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ If you use `use_as_body:"true"`, you can also set `is_protobuf:"true"`
 and put a protobuf type (convertible to proto.Message) in that field.
 It will be sent over wire as protobuf binary form.
 
+**Streaming**. If you use `use_as_body:"true"`, you can also set
+`is_stream:"true"`. In this case the field must be of type `io.ReadCloser`.
+On the client side put any object implementing `io.ReadCloser` to such
+a field in Request. It will be read and closed by the library and used
+as HTTP request body. On the server side your handler
+should read from the reader passed in that field of Request.
+(You don't have to read the entire body and to close it.)
+For Response, on the server side, the handler must put any object
+implementing `io.ReadCloser` to such a field of Response.
+The library will use it to generate HTTP response's body and close it.
+On the client side your code must read from that reader the entire response
+and then close it. If a streaming field is left `nil`, it is interpreted
+as empty body.
+
 Now let's write the function that generates the table of routes:
 
 ```go
@@ -173,6 +187,7 @@ $ app &
 $ client
 test
 87672h0m0s
+ABC XYZ
 ```
 
 Code generation code is located in directory [example/gen](./example/gen).

--- a/api_test.go
+++ b/api_test.go
@@ -2,6 +2,7 @@ package api2
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"testing"
 
@@ -166,6 +167,42 @@ func TestValidateRequestResponse(t *testing.T) {
 		{
 			obj: struct {
 				Foo *timestamppb.Timestamp `is_protobuf:"true"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+
+		{
+			obj: struct {
+				Foo io.ReadCloser `use_as_body:"true" is_stream:"true"`
+			}{},
+			request:   true,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				Foo io.ReadCloser `use_as_body:"true" is_stream:"true"`
+			}{},
+			request:   false,
+			wantPanic: false,
+		},
+		{
+			obj: struct {
+				Foo *io.ReadCloser `use_as_body:"true" is_stream:"true"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo string `use_as_body:"true" is_stream:"true"`
+			}{},
+			request:   true,
+			wantPanic: true,
+		},
+		{
+			obj: struct {
+				Foo io.ReadCloser `use_as_body:"true" is_stream:"true" is_protobuf:"true"`
 			}{},
 			request:   true,
 			wantPanic: true,

--- a/doc.go
+++ b/doc.go
@@ -68,6 +68,20 @@ If you use `use_as_body:"true"`, you can also set `is_protobuf:"true"`
 and put a protobuf type (convertible to proto.Message) in that field.
 It will be sent over wire as protobuf binary form.
 
+Streaming. If you use `use_as_body:"true"`, you can also set
+`is_stream:"true"`. In this case the field must be of type `io.ReadCloser`.
+On the client side put any object implementing `io.ReadCloser` to such
+a field in Request. It will be read and closed by the library and used
+as HTTP request body. On the server side your handler
+should read from the reader passed in that field of Request.
+(You don't have to read the entire body and to close it.)
+For Response, on the server side, the handler must put any object
+implementing `io.ReadCloser` to such a field of Response.
+The library will use it to generate HTTP response's body and close it.
+On the client side your code must read from that reader the entire response
+and then close it. If a streaming field is left `nil`, it is interpreted
+as empty body.
+
 Now let's write the function that generates the table of routes:
 
 	func GetRoutes(s *Foo) []api2.Route {

--- a/example/client.go
+++ b/example/client.go
@@ -56,3 +56,12 @@ func (c *Client) Since(ctx context.Context, req *SinceRequest) (res *SinceRespon
 	}
 	return
 }
+
+func (c *Client) Stream(ctx context.Context, req *StreamRequest) (res *StreamResponse, err error) {
+	res = &StreamResponse{}
+	err = c.api2client.Call(ctx, res, req)
+	if err != nil {
+		return nil, err
+	}
+	return
+}

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 	"time"
 
 	"github.com/starius/api2/example"
@@ -41,4 +43,20 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(sinceRes.Body.AsDuration())
+
+	streamRes, err := client.Stream(ctx, &example.StreamRequest{
+		Session: helloRes.Session,
+		Body:    io.NopCloser(strings.NewReader("abc xyz")),
+	})
+	if err != nil {
+		panic(err)
+	}
+	streamResBytes, err := io.ReadAll(streamRes.Body)
+	if err != nil {
+		panic(err)
+	}
+	if err := streamRes.Body.Close(); err != nil {
+		panic(err)
+	}
+	fmt.Println(string(streamResBytes))
 }

--- a/example/echo_service.go
+++ b/example/echo_service.go
@@ -1,10 +1,12 @@
 package example
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -74,5 +76,21 @@ func (s *EchoService) Since(ctx context.Context, req *SinceRequest) (*SinceRespo
 	duration := t2.Sub(t1)
 	return &SinceResponse{
 		Body: durationpb.New(duration),
+	}, nil
+}
+
+func (s *EchoService) Stream(ctx context.Context, req *StreamRequest) (*StreamResponse, error) {
+	if !s.sessions[req.Session] {
+		return nil, fmt.Errorf("bad session")
+	}
+	input, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	output := bytes.ToUpper(input)
+
+	return &StreamResponse{
+		Body: io.NopCloser(bytes.NewReader(output)),
 	}, nil
 }

--- a/example/openapi/openapi.json
+++ b/example/openapi/openapi.json
@@ -94,6 +94,17 @@
    "example.SinceResponse": {
     "type": "object"
    },
+   "example.StreamRequest": {
+    "properties": {
+     "session": {
+      "type": "string"
+     }
+    },
+    "type": "object"
+   },
+   "example.StreamResponse": {
+    "type": "object"
+   },
    "example.UserSettings": {}
   },
   "requestBodies": {
@@ -120,6 +131,15 @@
      "application/json": {
       "schema": {
        "$ref": "#/components/schemas/example.SinceRequest"
+      }
+     }
+    }
+   },
+   "example.StreamRequest": {
+    "content": {
+     "application/json": {
+      "schema": {
+       "$ref": "#/components/schemas/example.StreamRequest"
       }
      }
     }
@@ -192,6 +212,31 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/example.SinceResponse"
+        }
+       }
+      },
+      "description": "info"
+     },
+     "default": {
+      "description": ""
+     }
+    },
+    "tags": [
+     "example"
+    ]
+   }
+  },
+  "/stream": {
+   "put": {
+    "requestBody": {
+     "$ref": "#/components/requestBodies/example.StreamRequest"
+    },
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/example.StreamResponse"
         }
        }
       },

--- a/example/rego/routes.yaml
+++ b/example/rego/routes.yaml
@@ -10,3 +10,6 @@ example:
     Since:
       method: "POST"
       path: "/since"
+    Stream:
+      method: "PUT"
+      path: "/stream"

--- a/example/routes.go
+++ b/example/routes.go
@@ -11,5 +11,6 @@ func GetRoutes(s IEchoService) []api2.Route {
 		{Method: http.MethodPost, Path: "/hello", Handler: api2.Method(&s, "Hello")},
 		{Method: http.MethodPost, Path: "/echo", Handler: api2.Method(&s, "Echo")},
 		{Method: http.MethodPost, Path: "/since", Handler: api2.Method(&s, "Since")},
+		{Method: http.MethodPut, Path: "/stream", Handler: api2.Method(&s, "Stream")},
 	}
 }

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -19,6 +19,10 @@ example: {
 				"POST", "/since",
 				{"header":["session"]},
 				{}),
+			Stream: route<example.StreamRequest, example.StreamResponse>(
+				"PUT", "/stream",
+				{"header":["session"]},
+				{}),
 	},
 },
 }
@@ -78,6 +82,15 @@ export type SinceRequest = {
 
 
 export type SinceResponse = {
+}
+
+
+export type StreamRequest = {
+	session?: string
+}
+
+
+export type StreamResponse = {
 }
 
 

--- a/example/types.go
+++ b/example/types.go
@@ -4,6 +4,7 @@ package example
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -71,8 +72,18 @@ type SinceResponse struct {
 	Body *durationpb.Duration `use_as_body:"true" is_protobuf:"true"`
 }
 
+type StreamRequest struct {
+	Session string        `header:"session"`
+	Body    io.ReadCloser `use_as_body:"true" is_stream:"true"`
+}
+
+type StreamResponse struct {
+	Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+}
+
 type IEchoService interface {
 	Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error)
 	Echo(ctx context.Context, req *EchoRequest) (*EchoResponse, error)
 	Since(ctx context.Context, req *SinceRequest) (*SinceResponse, error)
+	Stream(ctx context.Context, req *StreamRequest) (*StreamResponse, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/invopop/yaml v0.2.0 // indirect
+	github.com/stretchr/testify v1.8.0
 	go.uber.org/goleak v1.1.12
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
 	golang.org/x/tools v0.1.12

--- a/json_transport.go
+++ b/json_transport.go
@@ -238,7 +238,9 @@ func prepare(objType reflect.Type) *preparedType {
 		headerKey := field.Tag.Get("header")
 		cookieKey := field.Tag.Get("cookie")
 		isBodyField := field.Tag.Get("use_as_body") == "true"
-		p.Protobuf = isBodyField && field.Tag.Get("is_protobuf") == "true"
+		if isBodyField {
+			p.Protobuf = field.Tag.Get("is_protobuf") == "true"
+		}
 		if queryKey != "" {
 			p.QueryMapping = append(p.QueryMapping, strMapping{
 				Field: i,

--- a/json_transport_test.go
+++ b/json_transport_test.go
@@ -525,6 +525,21 @@ func TestQueryAndHeader(t *testing.T) {
 			wantBody:  string(protobufSampleBytes),
 			cmpAsJson: true,
 		},
+		{
+			objPtr: &struct {
+				Foo *timestamppb.Timestamp `use_as_body:"true" is_protobuf:"true"`
+				Bar string                 `header:"bar"`
+			}{
+				Foo: protobufSampleObject,
+				Bar: "some field after is_protobuf field",
+			},
+			query:    true,
+			wantBody: string(protobufSampleBytes),
+			wantHeader: map[string][]string{
+				"Bar": []string{"some field after is_protobuf field"},
+			},
+			cmpAsJson: true,
+		},
 	}
 
 	for i, tc := range cases {

--- a/test/streams_test.go
+++ b/test/streams_test.go
@@ -1,0 +1,253 @@
+package api2
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/starius/api2"
+	"github.com/stretchr/testify/require"
+)
+
+type closeRecorder struct {
+	r      io.Reader
+	closed bool
+}
+
+func (c *closeRecorder) Read(p []byte) (n int, err error) {
+	return c.r.Read(p)
+}
+
+func (c *closeRecorder) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestStream(t *testing.T) {
+	type Request struct {
+		Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+	}
+
+	type Response struct {
+		Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+	}
+
+	xorHandler := func(ctx context.Context, req *Request) (res *Response, err error) {
+		r, w := io.Pipe()
+		go func() {
+			// Read byte by byte, xor with 0x42 and write to output stream.
+			buf := make([]byte, 1)
+			for {
+				n, err := req.Body.Read(buf)
+				if err != nil && err != io.EOF {
+					panic(err)
+				}
+				if n == 0 {
+					if err == io.EOF {
+						break
+					}
+					continue
+				}
+				if n > 1 {
+					panic(fmt.Errorf("expected to get <= 1 bytes, got %d", n))
+				}
+				buf[0] ^= 0x42
+				n, err2 := w.Write(buf)
+				if err2 != nil {
+					panic(err2)
+				}
+				if n != 1 {
+					panic(fmt.Errorf("expected to get n = 1 byte, got %d", n))
+				}
+				if err == io.EOF {
+					break
+				}
+			}
+			if err := w.Close(); err != nil {
+				panic(err)
+			}
+		}()
+		return &Response{
+			Body: r,
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodGet, Path: "/stream", Handler: xorHandler},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := api2.NewClient(routes, server.URL)
+
+	rc := &closeRecorder{r: bytes.NewReader([]byte{0x00, 0xFF, 0x11})}
+
+	req := &Request{
+		Body: rc,
+	}
+	res := &Response{}
+
+	err := client.Call(context.Background(), res, req)
+	if err != nil {
+		t.Errorf("request failed: %v.", err)
+	}
+
+	if !rc.closed {
+		t.Errorf("expected the library to close the request reader")
+	}
+
+	buf, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("failed to read response body: %v.", err)
+	}
+	want := []byte{0x42, 0xFF ^ 0x42, 0x11 ^ 0x42}
+	if !bytes.Equal(buf, want) {
+		t.Errorf("got buf=%v, want %v", buf, want)
+	}
+}
+
+func TestStreamNoBodyErrors(t *testing.T) {
+	type Request struct {
+		Body            io.ReadCloser `use_as_body:"true" is_stream:"true"`
+		SetResponseBody bool          `header:"set-response-body"`
+	}
+
+	type Response struct {
+		Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+	}
+
+	handler := func(ctx context.Context, req *Request) (res *Response, err error) {
+		if req.SetResponseBody {
+			return &Response{
+				Body: io.NopCloser(bytes.NewReader([]byte("123"))),
+			}, nil
+		} else {
+			return &Response{
+				Body: nil,
+			}, nil
+		}
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodGet, Path: "/stream", Handler: handler},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := api2.NewClient(routes, server.URL)
+
+	t.Run("request without body", func(t *testing.T) {
+		req := &Request{
+			Body:            nil,
+			SetResponseBody: true,
+		}
+		res := &Response{}
+		err := client.Call(context.Background(), res, req)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("response without body", func(t *testing.T) {
+		req := &Request{
+			Body:            io.NopCloser(bytes.NewReader([]byte("123"))),
+			SetResponseBody: false,
+		}
+		res := &Response{}
+		err := client.Call(context.Background(), res, req)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("request and response without body", func(t *testing.T) {
+		req := &Request{
+			Body:            nil,
+			SetResponseBody: false,
+		}
+		res := &Response{}
+		err := client.Call(context.Background(), res, req)
+		require.NoError(t, err)
+		_, err = io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+}
+
+func BenchmarkStream(b *testing.B) {
+	type Request struct {
+		Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+	}
+
+	type Response struct {
+		Body io.ReadCloser `use_as_body:"true" is_stream:"true"`
+	}
+
+	const mb = 1024 * 1024
+	b.SetBytes(mb)
+
+	nBytes := int64(b.N * mb)
+
+	handler := func(ctx context.Context, req *Request) (res *Response, err error) {
+		// Read whole request body.
+		n, err := io.Copy(io.Discard, req.Body)
+		if err != nil {
+			panic(err)
+		}
+		if n != nBytes {
+			panic(fmt.Errorf("expected to get n = %d, got %d", nBytes, n))
+		}
+
+		return &Response{
+			Body: io.NopCloser(&io.LimitedReader{
+				R: rand.New(rand.NewSource(42)),
+				N: nBytes,
+			}),
+		}, nil
+	}
+
+	routes := []api2.Route{
+		{Method: http.MethodGet, Path: "/stream", Handler: handler},
+	}
+
+	mux := http.NewServeMux()
+	api2.BindRoutes(mux, routes, api2.MaxBody(nBytes))
+	server := httptest.NewServer(mux)
+	b.Cleanup(server.Close)
+
+	client := api2.NewClient(routes, server.URL, api2.MaxBody(nBytes))
+
+	req := &Request{
+		Body: io.NopCloser(&io.LimitedReader{
+			R: rand.New(rand.NewSource(42)),
+			N: nBytes,
+		}),
+	}
+	res := &Response{}
+
+	err := client.Call(context.Background(), res, req)
+	if err != nil {
+		b.Errorf("request failed: %v.", err)
+	}
+
+	n, err := io.Copy(io.Discard, res.Body)
+	if err != nil {
+		panic(err)
+	}
+	if n != nBytes {
+		panic(fmt.Errorf("expected to get n = %d, got %d", nBytes, n))
+	}
+}


### PR DESCRIPTION
**Streaming**. If you use `use_as_body:"true"`, you can also set
`is_stream:"true"`. In this case the field must be of type `io.ReadCloser`.
On the client side put any object implementing `io.ReadCloser` to such
a field in Request. It will be read and closed by the library and used
as HTTP request body. On the server side your handler
should read from the reader passed in that field of Request.
(You don't have to read the entire body and to close it.)
For Response, on the server side, the handler must put any object
implementing `io.ReadCloser` to such a field of Response.
The library will use it to generate HTTP response's body and close it.
On the client side your code must read from that reader the entire response
and then close it.