### PR TITLE
typegen: put doc of a deprecated field above

### DIFF
--- a/example/openapi/openapi.json
+++ b/example/openapi/openapi.json
@@ -108,6 +108,14 @@
    },
    "example.EchoResponse": {
     "properties": {
+     "old": {
+      "description": "@deprecated ! Use field Text.",
+      "type": "string"
+     },
+     "old2": {
+      "description": "@deprecated The field is DEPRECATED!",
+      "type": "string"
+     },
      "text": {
       "description": "field comment.",
       "type": "string"

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -14,7 +14,7 @@ example: {
 			Echo: route<example.EchoRequest, example.EchoResponse>(
 				"POST", "/echo/:user",
 				{"header":["session"],"json":["text","bar","code","dir","items","maps"]},
-				{"json":["text"]}),
+				{"json":["text","old","old2"]}),
 			Since: route<example.SinceRequest, example.SinceResponse>(
 				"POST", "/since",
 				{"header":["session"]},
@@ -81,6 +81,10 @@ export type UserSettings = Record<string, any> |  null
 // EchoResponse.
 export type EchoResponse = {
 	text: string // field comment.
+	/** @deprecated ! Use field Text. */
+	old: string
+	/** @deprecated The field is DEPRECATED! */
+	old2: string
 }
 
 

--- a/example/types.go
+++ b/example/types.go
@@ -54,6 +54,8 @@ type EchoRequest struct {
 // EchoResponse.
 type EchoResponse struct {
 	Text string `json:"text"` // field comment.
+	Old  string `json:"old"`  // Deprecated! Use field Text.
+	Old2 string `json:"old2"` // The field is DEPRECATED!
 }
 
 type HelloRequest struct {

--- a/typegen/parse.go
+++ b/typegen/parse.go
@@ -78,7 +78,15 @@ func (this *Parser) isVisited(t reflect.Type) bool {
 var re = regexp.MustCompile(`[\n\t\r]+`)
 
 func FormatDoc(str string) string {
-	return strings.TrimSpace(re.ReplaceAllString(str, " "))
+	doc := strings.TrimSpace(re.ReplaceAllString(str, " "))
+	idoc := strings.ToLower(doc)
+	if strings.HasPrefix(idoc, "deprecated") {
+		// Turn leading "deprecated into @deprecated".
+		doc = "@deprecated " + doc[len("deprecated"):]
+	} else if strings.Contains(idoc, "deprecated") {
+		doc = "@deprecated " + doc
+	}
+	return doc
 }
 
 func (this *Parser) visitType(t reflect.Type) {

--- a/typegen/typescript.printer.go
+++ b/typegen/typescript.printer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path"
 	"reflect"
+	"strings"
 	"text/template"
 )
 
@@ -21,7 +22,12 @@ export declare namespace {{$namespace}} {
 
 const RecordTemplate = `{{ range $field := .Embedded}} {{$field | RefName}} & {{end}}{
 {{- range $field := .Fields}}
+	{{- if hasPrefix $field.Doc "@deprecated" }}
+	/** {{ $field.Doc }} */
+	{{$field | Row}}
+	{{- else }}
 	{{$field | Row}}{{if $field.Doc| ne ""}} // {{$field.Doc}}{{end}}
+	{{- end }}
 {{- end}}
 }
 `
@@ -118,6 +124,7 @@ func PrintTsTypes(parser *Parser, w io.Writer, stringify Stringifier) {
 
 				return fmt.Sprintf("%s%s: %s%s", keyName, optionalText, fieldType, nullText)
 			},
+			"hasPrefix": strings.HasPrefix,
 		}).Parse(RecordTemplate)
 		panicIf(err)
 		w := &bytes.Buffer{}


### PR DESCRIPTION
Detect if the doc tells that the field is depreated, start such a doc with "@deprecated" and put the doc itself above the field.