### PR TITLE
typegen: optionally generate enums with prefix

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -6,7 +6,6 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -130,7 +129,7 @@ func csvEncodeError(ctx context.Context, w http.ResponseWriter, err error) error
 }
 
 func csvDecodeError(ctx context.Context, res *http.Response) error {
-	message, err := ioutil.ReadAll(res.Body)
+	message, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/example/gen/main.go
+++ b/example/gen/main.go
@@ -15,6 +15,7 @@ func main() {
 			&example.CustomType{},
 			&example.CustomType2{},
 		},
+		EnumsWithPrefix: true,
 	})
 	api2.GenerateOpenApiSpec(&api2.TypesGenConfig{
 		OutDir: "./openapi",

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -34,12 +34,12 @@ example: {
 	},
 },
 }
-export const OpCodeEnum  = {
+export const example_OpCodeEnum = {
     "Op_Add": ,
     "Op_Read": ,
     "Op_Write": ,
 } as const
-export const DirectionEnum  = {
+export const example_DirectionEnum = {
     "East": 1,
     "North": 0,
     "South": 2,
@@ -69,9 +69,9 @@ export type EchoRequest = {
 }
 
 
-export type OpCode = typeof OpCodeEnum[keyof typeof OpCodeEnum]
+export type OpCode = typeof example_OpCodeEnum[keyof typeof example_OpCodeEnum]
 
-export type Direction = typeof DirectionEnum[keyof typeof DirectionEnum]
+export type Direction = typeof example_DirectionEnum[keyof typeof example_DirectionEnum]
 
 export type CustomType2 =  example.UserSettings & {
 }

--- a/json_transport.go
+++ b/json_transport.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -139,10 +138,10 @@ func (h *JsonTransport) EncodeRequest(ctx context.Context, method, urlStr string
 		body := bytes.NewReader(requestBody)
 		snapshot := *body
 		request.ContentLength = int64(len(requestBody))
-		request.Body = ioutil.NopCloser(body)
+		request.Body = io.NopCloser(body)
 		request.GetBody = func() (io.ReadCloser, error) {
 			r := snapshot
-			return ioutil.NopCloser(&r), nil
+			return io.NopCloser(&r), nil
 		}
 	}
 
@@ -166,7 +165,7 @@ func (h *JsonTransport) DecodeError(ctx context.Context, res *http.Response) err
 		return h.ErrorDecoder(ctx, res)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}
@@ -577,7 +576,7 @@ func readQueryHeaderCookie(objPtr interface{}, bodyReadCloser io.ReadCloser, que
 			if !ok {
 				panic("protobuf field is not of type proto.Message")
 			}
-			buf, err := ioutil.ReadAll(bodyReadCloser)
+			buf, err := io.ReadAll(bodyReadCloser)
 			if err != nil {
 				return err
 			}
@@ -587,7 +586,7 @@ func readQueryHeaderCookie(objPtr interface{}, bodyReadCloser io.ReadCloser, que
 		} else if p.Stream {
 			fieldValue.Set(reflect.ValueOf(bodyReadCloser))
 		} else if p.Raw {
-			buf, err := ioutil.ReadAll(bodyReadCloser)
+			buf, err := io.ReadAll(bodyReadCloser)
 			if err != nil {
 				return err
 			}
@@ -619,7 +618,7 @@ func readQueryHeaderCookie(objPtr interface{}, bodyReadCloser io.ReadCloser, que
 
 	if !p.Stream {
 		// Drain the reader in case we skipped parsing or something is left.
-		if _, err := io.Copy(ioutil.Discard, bodyReadCloser); err != nil {
+		if _, err := io.Copy(io.Discard, bodyReadCloser); err != nil {
 			return err
 		}
 	}

--- a/static_client.go
+++ b/static_client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -235,14 +234,14 @@ func generateClient(getRoutes ...interface{}) error {
 	}
 
 	// Check that the file does not exist or was generated.
-	oldContent, err := ioutil.ReadFile(clientFile)
+	oldContent, err := os.ReadFile(clientFile)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unknown error when reading from %s: %v", clientFile, err)
 	} else if err == nil && !codeGeneratedRE.Match(oldContent) {
 		return fmt.Errorf("file %s exists and was not generated; please remove it to proceed", clientFile)
 	}
 
-	if err := ioutil.WriteFile(clientFile, []byte(code), 0644); err != nil {
+	if err := os.WriteFile(clientFile, []byte(code), 0644); err != nil {
 		return fmt.Errorf("failed to write file %s: %v", clientFile, err)
 	}
 

--- a/ts_client.go
+++ b/ts_client.go
@@ -89,11 +89,12 @@ var tsClientTemplate = template.Must(template.New("ts_static_client").Parse(tsCl
 var tsClientUtilsTemplate = template.Must(template.New("ts_static_client_utils").Parse(templateHeaderDefault))
 
 type TypesGenConfig struct {
-	OutDir         string
-	ClientTemplate *template.Template
-	Routes         []interface{}
-	Types          []interface{}
-	Blacklist      []BlacklistItem
+	OutDir          string
+	ClientTemplate  *template.Template
+	Routes          []interface{}
+	Types           []interface{}
+	Blacklist       []BlacklistItem
+	EnumsWithPrefix bool
 }
 
 func panicIf(err error) {
@@ -145,7 +146,7 @@ func GenerateTSClient(options *TypesGenConfig) {
 		panicIf(err)
 	}
 	parser.ParseRaw(options.Types...)
-	typegen.PrintTsTypes(parser, typesFile, SerializeCustom)
+	typegen.PrintTsTypes(parser, typesFile, SerializeCustom, typegen.EnumsWithPrefix(options.EnumsWithPrefix))
 	panicIf(err)
 
 }


### PR DESCRIPTION
A enum is a const in typescript and can not be put into a namespace. To prevent name collisions between enums, I added package name as a prefix. To enable this behaviour, pass EnumsWithPrefix option to PrintTsTypes or set EnumsWithPrefix to true in TypesGenConfig.