### PR TITLE
typegen/enums: use JSON encoding, use any types

### DIFF
--- a/example/openapi/openapi.json
+++ b/example/openapi/openapi.json
@@ -57,6 +57,14 @@
    }
   },
   "schemas": {
+   "example.Color": {
+    "enum": [
+     "color_blue",
+     "color_green",
+     "color_red"
+    ],
+    "type": "number"
+   },
    "example.CustomType2": {
     "allOf": [
      {
@@ -108,6 +116,9 @@
    },
    "example.EchoResponse": {
     "properties": {
+     "color": {
+      "$ref": "#/components/schemas/example.Color"
+     },
      "old": {
       "description": "@deprecated ! Use field Text.",
       "type": "string"

--- a/example/ts-types/gen.ts
+++ b/example/ts-types/gen.ts
@@ -14,7 +14,7 @@ example: {
 			Echo: route<example.EchoRequest, example.EchoResponse>(
 				"POST", "/echo/:user",
 				{"header":["session"],"json":["text","bar","code","dir","items","maps"]},
-				{"json":["text","old","old2"]}),
+				{"json":["text","old","old2","color"]}),
 			Since: route<example.SinceRequest, example.SinceResponse>(
 				"POST", "/since",
 				{"header":["session"]},
@@ -35,15 +35,20 @@ example: {
 },
 }
 export const example_OpCodeEnum = {
-    "Op_Add": ,
-    "Op_Read": ,
-    "Op_Write": ,
+    "Op_Add": "add",
+    "Op_Read": "read",
+    "Op_Write": "write",
 } as const
 export const example_DirectionEnum = {
     "East": 1,
     "North": 0,
     "South": 2,
     "West": 3,
+} as const
+export const example_ColorEnum = {
+    "ColorBlue": "color_blue",
+    "ColorGreen": "color_green",
+    "ColorRed": "color_red",
 } as const
 
 export declare namespace example {
@@ -85,8 +90,11 @@ export type EchoResponse = {
 	old: string
 	/** @deprecated The field is DEPRECATED! */
 	old2: string
+	color: example.Color
 }
 
+
+export type Color = typeof example_ColorEnum[keyof typeof example_ColorEnum]
 
 export type SinceRequest = {
 	session?: string

--- a/example/types.go
+++ b/example/types.go
@@ -3,7 +3,9 @@ package example
 //go:generate go run ./gen/...
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -28,6 +30,68 @@ const (
 	Op_Write
 	Op_Add
 )
+
+func (o OpCode) String() string {
+	if o == Op_Read {
+		return "read"
+	} else if o == Op_Write {
+		return "write"
+	} else if o == Op_Add {
+		return "add"
+	} else {
+		return ""
+	}
+}
+
+type Color byte
+
+const (
+	ColorRed Color = iota + 1
+	ColorGreen
+	ColorBlue
+)
+
+// If a type has both MarshalJSON and String, MarshalJSON is used
+// to produce enum values.
+
+func (c Color) String() string {
+	if c == ColorRed {
+		return "red"
+	} else if c == ColorGreen {
+		return "green"
+	} else if c == ColorBlue {
+		return "blue"
+	} else {
+		return ""
+	}
+}
+
+func (c Color) MarshalJSON() ([]byte, error) {
+	if c == ColorRed {
+		return []byte(`"color_red"`), nil
+	} else if c == ColorGreen {
+		return []byte(`"color_green"`), nil
+	} else if c == ColorBlue {
+		return []byte(`"color_blue"`), nil
+	} else {
+		return []byte(`""`), nil
+	}
+}
+
+func (c *Color) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte(`"color_red"`)) {
+		*c = ColorRed
+	} else if bytes.Equal(data, []byte(`"color_green"`)) {
+		*c = ColorGreen
+	} else if bytes.Equal(data, []byte(`"color_blue"`)) {
+		*c = ColorBlue
+	} else if bytes.Equal(data, []byte(`""`)) {
+		*c = 0
+	} else {
+		return fmt.Errorf("unknown color")
+	}
+	return nil
+}
 
 type UserSettings map[string]interface{}
 type CustomType struct {
@@ -54,9 +118,10 @@ type EchoRequest struct {
 
 // EchoResponse.
 type EchoResponse struct {
-	Text string `json:"text"` // field comment.
-	Old  string `json:"old"`  // Deprecated! Use field Text.
-	Old2 string `json:"old2"` // The field is DEPRECATED!
+	Text  string `json:"text"` // field comment.
+	Old   string `json:"old"`  // Deprecated! Use field Text.
+	Old2  string `json:"old2"` // The field is DEPRECATED!
+	Color Color  `json:"color"`
 }
 
 type HelloRequest struct {


### PR DESCRIPTION
Encoding of enum type is chosen as follows:

 - if the type is string, use that string
 - if the type has String() method, call it
 - if the type has MarshalJSON() method, call it
 - if the type is int or int32, use that value
 - empty string