### PR TITLE
client: fix streaming of response

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,7 +133,7 @@ func (c *Client) Call(ctx context.Context, response, request interface{}) error 
 	}
 	res.Body = http.MaxBytesReader(nil, res.Body, c.maxBody)
 	defer func() {
-		if !bodyCloseNeeded(ctx, request, response, t) {
+		if !bodyCloseNeeded(ctx, response, request, t) {
 			return
 		}
 		if err := res.Body.Close(); err != nil {


### PR DESCRIPTION
The order of arguments request and response was wrong, that is why it accidentally worked when both request and response use streaming.